### PR TITLE
performance enhancements to drawing primitives

### DIFF
--- a/nodebox/graphics/context.py
+++ b/nodebox/graphics/context.py
@@ -599,7 +599,7 @@ def rect(x, y, width, height, **kwargs):
         glVertex2f(x+width, y+height)
         glVertex2f(x, y+height)
         glEnd()
-            
+
 def triangle(x1, y1, x2, y2, x3, y3, **kwargs):
     """ Draws the triangle created by connecting the three given points.
         The current stroke, strokewidth and fill color are applied.
@@ -685,57 +685,61 @@ def gcd(a, b):
     return gcd(b, a % b) if b else a
 
 _stars = {} #TODO: LRU?
-def star(x, y, points=20, outer=100, inner=50, **kwargs):
+def fast_star(x, y, points=20, outer=100, inner=50, **kwargs):
     """ Draws a star with the given points, outer radius and inner radius.
         The current stroke, strokewidth and fill color are applied.
     """
-    if kwargs.get("draw", True):
-        scale = gcd(inner, outer)
-        iscale = inner / scale
-        oscale = outer / scale
-        cached = _stars.get((points, iscale, oscale), [])
-        if not cached:
-            radii = [oscale, iscale] * int(points+1); radii.pop() # which radius?
-            f = pi / points
-            v = [(r*sin(i*f), r*cos(i*f)) for i, r in enumerate(radii)]
-            cached.append(precompile(lambda:(
-                glBegin(GL_TRIANGLE_FAN),
-                glVertex2f(0, 0),
-                [glVertex2f(vx, vy) for (vx, vy) in v],
-                glEnd()
-            )))
-            cached.append(precompile(lambda:(
-                glBegin(GL_LINE_LOOP),
-                [glVertex2f(vx, vy) for (vx, vy) in v],
-                glEnd()
-            )))
-            _stars[(points, iscale, oscale)] = cached
+    scale = gcd(inner, outer)
+    iscale = inner / scale
+    oscale = outer / scale
+    cached = _stars.get((points, iscale, oscale), [])
+    if not cached:
+        radii = [oscale, iscale] * int(points+1); radii.pop() # which radius?
+        f = pi / points
+        v = [(r*sin(i*f), r*cos(i*f)) for i, r in enumerate(radii)]
+        cached.append(precompile(lambda:(
+            glBegin(GL_TRIANGLE_FAN),
+            glVertex2f(0, 0),
+            [glVertex2f(vx, vy) for (vx, vy) in v],
+            glEnd()
+        )))
+        cached.append(precompile(lambda:(
+            glBegin(GL_LINE_LOOP),
+            [glVertex2f(vx, vy) for (vx, vy) in v],
+            glEnd()
+        )))
+        _stars[(points, iscale, oscale)] = cached
 
-        fill, stroke, strokewidth, strokestyle = color_mixin(**kwargs)
-        for i, clr in enumerate((fill, stroke)):
-            if clr is not None and (i == 0 or strokewidth > 0):
-                if i == 1: 
-                    glLineWidth(strokewidth)
-                    if strokestyle != _strokestyle:
-                        glLineDash(strokestyle)
-                glColor4f(clr[0], clr[1], clr[2], clr[3] * _alpha)
-                glPushMatrix()
-                glTranslatef(x, y, 0)
-                glScalef(scale, scale, 1)
-                glCallList(cached[i])
-                glPopMatrix()
-    else:
-        # For whatever reason, the original api specified that you
-        # can get the path to the star. This is about 30x slower,
-        # but I'm keeping it here for backwards compatibility.
-        p = BezierPath(**kwargs)
-        p.moveto(x, y+outer)
-        for i in range(0, int(2*points)+1):
-            r = (outer, inner)[i%2]
-            a = pi*i/points
-            p.lineto(x+r*sin(a), y+r*cos(a))
-        p.closepath()
-        return p
+    fill, stroke, strokewidth, strokestyle = color_mixin(**kwargs)
+    for i, clr in enumerate((fill, stroke)):
+        if clr is not None and (i == 0 or strokewidth > 0):
+            if i == 1: 
+                glLineWidth(strokewidth)
+                if strokestyle != _strokestyle:
+                    glLineDash(strokestyle)
+            glColor4f(clr[0], clr[1], clr[2], clr[3] * _alpha)
+            glPushMatrix()
+            glTranslatef(x, y, 0)
+            glScalef(scale, scale, 1)
+            glCallList(cached[i])
+            glPopMatrix()
+
+def star(x, y, points=20, outer=100, inner=50, **kwargs):
+    """ Draws a star with the given points, outer radius and inner radius.
+        The current stroke, strokewidth and fill color are applied.
+        This is about 20x slower than fast_star; use it only if you need the path returned.
+    """
+    p = BezierPath(**kwargs)
+    p.moveto(x, y+outer)
+    for i in range(0, int(2*points)+1):
+        r = (outer, inner)[i%2]
+        a = pi*i/points
+        p.lineto(x+r*sin(a), y+r*cos(a))
+    p.closepath()
+
+    if kwargs.get("draw", True):
+        p.draw(**kwargs)
+    return p
 
 #=====================================================================================================
 


### PR DESCRIPTION
I've made the following performance enhancements:
-  `line()`: 12-15% faster via `GL_LINES` instead of `GL_LINE_LOOP` 
- `triangle()`: 15% faster via `GL_TRIANGLES` instead of `GL_POLGYON` and avoiding calls to `glLineDash` where possible.
- `ellipse()`: 12% faster via `GL_TRIANGLE_FAN` instead of `GL_POLYGON` and avoiding calls to glLineDash where possible.
- `star()`: 15x (thats times, not percent) faster via using `GL_TRIANGLE_FAN` instead of `BezierPath`. This is the only controversial change; As a result of doing the drawing in opengl, I no longer construct the bezier path in the case that `draw=True`. I maintained the old code branch for `draw=False`. I'm not sure how much client code depends on this, but I feel like the performance improvement is probably worth it. If necessary, I could move the opengl code to a differently named function.
