### PR TITLE
Bugfix releasing a key that was pressed over another window (i.e. Shift)

### DIFF
--- a/nodebox/graphics/context.py
+++ b/nodebox/graphics/context.py
@@ -3807,7 +3807,10 @@ class Canvas(list, Prototype, EventHandler):
             layer.on_key_release(self.key)
         self.on_key_release(self.key)
         self._keys.char = ""
-        self._keys.remove(keycode)
+        try:
+            self._keys.remove(keycode)
+        except ValueError:
+            pass
         self._keys.pressed = False
 
     def _on_text(self, text):


### PR DESCRIPTION
Bug: Open a Nodebox window, go to another X window, press "Shift" key, focus again on the Nodebox window with the mouse and release "Shift" key. Nodebox exits with a ValueError exception because the key is not in the _keys list of pressed keys.
Environment: Xubuntu Linux 14.04 (XFCE desktop)

Solution: ignore ValueError exceptions when removing keys from the _keys list