### PR TITLE
Update context.py

### DIFF
--- a/nodebox/graphics/context.py
+++ b/nodebox/graphics/context.py
@@ -587,7 +587,7 @@ def rect(x, y, width, height, **kwargs):
     fill, stroke, strokewidth, strokestyle = color_mixin(**kwargs)
     if fill is not None:
         glColor4f(fill[0], fill[1], fill[2], fill[3] * _alpha)
-        glRectf(x, y, x+width, y+width)
+        glRectf(x, y, x+width, y+height)
 
     if stroke is not None and strokewidth > 0:
         glLineWidth(strokewidth)


### PR DESCRIPTION
Fix display for rect primitive which can only draw squares in some cases
