### PR TITLE
Trying to adapt the code to Python3+

### DIFF
--- a/nodebox/ext/psyco/__init__.py
+++ b/nodebox/ext/psyco/__init__.py
@@ -28,7 +28,7 @@ except ImportError:
 # Try to import the dynamic-loading _psyco and report errors
 try:
     import _psyco
-except ImportError, e:
+except ImportError as e:
     extramsg = ''
     import sys, imp
     try:
@@ -43,7 +43,7 @@ except ImportError, e:
         extramsg = (" (check that the compiled extension '%s' is for "
                     "the correct Python version; this is Python %s)" %
                     (filename, sys.version.split()[0]))
-    raise ImportError, str(e) + extramsg
+    raise ImportError(str(e) + extramsg)
 
 # Publish important data by importing them in the package
 from support import __version__, error, warning, _getrealframe, _getemulframe

--- a/nodebox/ext/psyco/core.py
+++ b/nodebox/ext/psyco/core.py
@@ -141,12 +141,12 @@ up to the given depth of indirection."""
                  if isinstance(o, types.MethodType)
                  or isinstance(o, types.FunctionType)]
         if not funcs:
-            raise error, ("nothing bindable found in %s object" %
+            raise error("nothing bindable found in %s object" %
                           type(x).__name__)
         for o in funcs:
             bind(o, rec)
         return
-    raise TypeError, "cannot bind %s objects" % type(x).__name__
+    raise TypeError("cannot bind %s objects" % type(x).__name__)
 
 
 def unbind(x):
@@ -167,7 +167,7 @@ def unbind(x):
              or isinstance(o, types.FunctionType)):
                 unbind(o)
         return
-    raise TypeError, "cannot unbind %s objects" % type(x).__name__
+    raise TypeError("cannot unbind %s objects" % type(x).__name__)
 
 
 def proxy(x, rec=None):
@@ -186,7 +186,7 @@ up to the given depth of indirection."""
     if isinstance(x, types.MethodType):
         p = proxy(x.im_func, rec)
         return new.instancemethod(p, x.im_self, x.im_class)
-    raise TypeError, "cannot proxy %s objects" % type(x).__name__
+    raise TypeError("cannot proxy %s objects" % type(x).__name__)
 
 
 def unproxy(proxy):
@@ -198,7 +198,7 @@ does not trigger compilation nor execution of any compiled code."""
     if isinstance(proxy, types.MethodType):
         f = unproxy(proxy.im_func)
         return new.instancemethod(f, proxy.im_self, proxy.im_class)
-    raise TypeError, "%s objects cannot be proxies" % type(proxy).__name__
+    raise TypeError("%s objects cannot be proxies" % type(proxy).__name__)
 
 
 def cannotcompile(x):
@@ -211,7 +211,7 @@ or code object."""
     if isinstance(x, types.CodeType):
         _psyco.cannotcompile(x)
     else:
-        raise TypeError, "unexpected %s object" % type(x).__name__
+        raise TypeError("unexpected %s object" % type(x).__name__)
 
 
 def dumpcodebuf():

--- a/nodebox/ext/psyco/kdictproxy.py
+++ b/nodebox/ext/psyco/kdictproxy.py
@@ -56,8 +56,8 @@ except ImportError:
             return default
         def pop(self, key, *args):
             if len(args) > 1:
-                raise TypeError, "pop expected at most 2 arguments, got "\
-                                  + repr(1 + len(args))
+                raise TypeError("pop expected at most 2 arguments, got "\
+                                  + repr(1 + len(args)))
             try:
                 value = self[key]
             except KeyError:
@@ -70,7 +70,7 @@ except ImportError:
             try:
                 k, v = self.iteritems().next()
             except StopIteration:
-                raise KeyError, 'container is empty'
+                raise KeyError('container is empty')
             del self[k]
             return (k, v)
         def update(self, other):

--- a/nodebox/ext/psyco/profiler.py
+++ b/nodebox/ext/psyco/profiler.py
@@ -189,7 +189,7 @@ class Profiler:
         
         try:
             self.do_start()
-        except error, e:
+        except error as e:
             if logger:
                 logger.write('%s: disabled by psyco.error:' % (
                     self.__class__.__name__), 4)

--- a/nodebox/ext/psyco/support.py
+++ b/nodebox/ext/psyco/support.py
@@ -26,7 +26,7 @@ def warn(msg):
 #
 __version__ = 0x010502f0
 if _psyco.PSYVER != __version__:
-    raise error, "version mismatch between Psyco parts, reinstall it"
+    raise error("version mismatch between Psyco parts, reinstall it")
 
 version_info = (__version__ >> 24,
                 (__version__ >> 16) & 0xff,
@@ -123,16 +123,16 @@ class PsycoFrame(Frame):
         elif attr == 'f_restricted':
             result = self.f_builtins is not __builtins__
         elif attr == 'f_locals':
-            raise AttributeError, ("local variables of functions run by Psyco "
+            raise AttributeError("local variables of functions run by Psyco "
                                    "cannot be accessed in any way, sorry")
         else:
-            raise AttributeError, ("emulated Psyco frames have "
-                                   "no '%s' attribute" % attr)
+            raise AttributeError("emulated Psyco frames have "
+                                   "no '" + str(attr) + "' attribute" )
         self.__dict__[attr] = result
         return result
 
     def __setattr__(self, attr, value):
-        raise AttributeError, "Psyco frame objects are read-only"
+        raise AttributeError("Psyco frame objects are read-only")
 
     def __delattr__(self, attr):
         if attr == 'f_trace':
@@ -140,7 +140,7 @@ class PsycoFrame(Frame):
             # buggy behavior: you can 'del f.f_trace' as often as you like
             # even without having set it previously.
             return
-        raise AttributeError, "Psyco frame objects are read-only"
+        raise AttributeError("Psyco frame objects are read-only")
 
 
 def embedframe(result):

--- a/nodebox/graphics/__init__.py
+++ b/nodebox/graphics/__init__.py
@@ -1,11 +1,11 @@
-import bezier
-import context
-import geometry
-import physics
-import shader
+import nodebox.graphics.bezier
+import nodebox.graphics.context
+import nodebox.graphics.geometry
+import nodebox.graphics.physics
+import nodebox.graphics.shader
 
-from noise   import noise
-from context import *
+from nodebox.graphics.noise   import noise
+from nodebox.graphics.context import *
 
 physics.line    = context.line
 physics.ellipse = context.ellipse
@@ -19,6 +19,9 @@ physics.Text    = context.Text
 # - FRAME  => frame()
 
 canvas = Canvas()
+
+def get_canvas():
+    return canvas
 
 def size(width=None, height=None):
     if width is not None:

--- a/nodebox/graphics/bezier.py
+++ b/nodebox/graphics/bezier.py
@@ -7,7 +7,7 @@
 
 # Thanks to Prof. F. De Smedt at the Vrije Universiteit Brussel.
 
-from context import BezierPath, PathElement, PathError, Point, MOVETO, LINETO, CURVETO, CLOSE
+from nodebox.graphics.context import BezierPath, PathElement, PathError, Point, MOVETO, LINETO, CURVETO, CLOSE
 from math import sqrt, pow
 
 class DynamicPathElement(PathElement):
@@ -156,7 +156,7 @@ def _locate(path, t, segments=None):
     if segments == None:
         segments = segment_lengths(path, relative=True) 
     if len(segments) == 0:
-        raise PathError, "The given path is empty"
+        raise PathError("The given path is empty")
     for i, el in enumerate(path):
         if i == 0 or el.cmd == MOVETO:
             closeto = Point(el.x, el.y)
@@ -179,7 +179,7 @@ def point(path, t, segments=None):
         the length during each iteration.
     """
     if len(path) == 0:
-        raise PathError, "The given path is empty"
+        raise PathError("The given path is empty")
     i, t, closeto = _locate(path, t, segments=segments)
     x0, y0 = path[i].x, path[i].y
     p1 = path[i+1]
@@ -198,14 +198,14 @@ def point(path, t, segments=None):
         x, y, c1x, c1y, c2x, c2y = curvepoint(t, x0, y0, x1, y1, x2, y2, x3, y3)
         return DynamicPathElement(CURVETO, ((c1x, c1y), (c2x, c2y), (x, y)))
     else:
-        raise PathError, "Unknown cmd '%s' for p1 %s" % (p1.cmd, p1)
+        raise PathError("Unknown cmd '" + str(p1.cmd) + "' for p1 " + str(p1))
         
 def points(path, amount=100, start=0.0, end=1.0, segments=None):
     """ Returns an iterator with a list of calculated points for the path.
         To omit the last point on closed paths: end=1-1.0/amount
     """
     if len(path) == 0:
-        raise PathError, "The given path is empty"
+        raise PathError("The given path is empty")
     n = end - start
     d = n
     if amount > 1: 
@@ -344,7 +344,7 @@ def insert_point(path, t):
         pt_x, pt_y, pt_c1x, pt_c1y, pt_c2x, pt_c2y, pt_h1x, pt_h1y, pt_h2x, pt_h2y = \
             curvepoint(t, x0, y0, x1, y1, x2, y2, x3, y3, True)
     else:
-        raise PathError, "Locate should not return a MOVETO"
+        raise PathError("Locate should not return a MOVETO")
 
     # NodeBox for OpenGL modifies the path in place,
     # NodeBox for Mac OS X returned a path copy (see inactive code below).
@@ -357,7 +357,7 @@ def insert_point(path, t):
     elif pt_cmd == LINETO:
         path.insert(i+1, PathElement(cmd=LINETO, pts=[(pt_x, pt_y)]))
     else:
-        raise PathError, "Didn't expect pt_cmd %s here" % pt_cmd
+        raise PathError("Didn't expect pt_cmd " + str(pt_cmd) + " here")
     return path[i+1]
     
     #new_path = BezierPath(None)

--- a/nodebox/graphics/geometry.py
+++ b/nodebox/graphics/geometry.py
@@ -312,7 +312,8 @@ class Point(object):
 
     def _get_xy(self):
         return (self.x, self.y)
-    def _set_xy(self, (x,y)):
+    def _set_xy(self, pos):
+        x, y = pos
         self.x = x
         self.y = y
         
@@ -562,7 +563,7 @@ def _tessellate_error(code):
     while e[i]: 
         s += chr(e[i])
         i += 1
-    raise TessellationError, s
+    raise TessellationError(s)
 
 _cache = {}
 

--- a/nodebox/graphics/physics.py
+++ b/nodebox/graphics/physics.py
@@ -66,7 +66,8 @@ class Vector(object):
             
     def _get_xyz(self):
         return (self.x, self.y, self.z)
-    def _set_xyz(self, (x,y,z)):
+    def _set_xyz(self, pos):
+        x, y, z = pos
         self.x = float(x)
         self.y = float(y)
         self.z = float(z)
@@ -74,7 +75,8 @@ class Vector(object):
         
     def _get_xy(self):
         return (self.x, self.y)
-    def _set_xy(self, (x,y)):
+    def _set_xy(self, pos):
+        x, y = pos
         self.x = float(x)
         self.y = float(y)
     xy = property(_get_xy, _set_xy)
@@ -223,7 +225,7 @@ class Vector(object):
                       self.x*v.y - self.y*v.x)
 
     def __neg__(self):
-		return Vector(-self.x, -self.y, -self.z)
+        return Vector(-self.x, -self.y, -self.z)
 
     def __eq__(self, v):
         return isinstance(v, Vector) and self.x == v.x and self.y == v.y and self.z == v.z
@@ -957,7 +959,7 @@ def deepcopy(o):
         return o.__class__(deepcopy(v) for v in o)
     if isinstance(o, dict):
         return dict((deepcopy(k), deepcopy(v)) for k,v in o.iteritems())
-    raise Exception, "don't know how to copy %s" % o.__class__.__name__
+    raise Exception("don't know how to copy " + str(o.__class__.__name__))
 
 class Node(object):
     
@@ -1212,7 +1214,7 @@ class Graph(dict):
         try: 
             return dict.__getitem__(self, id)
         except KeyError:
-            raise KeyError, "no node with id '%s' in graph" % id
+            raise KeyError("no node with id '" + str(id) + "' in graph")
     
     def append(self, base, *args, **kwargs):
         """ Appends a Node or Edge to the graph: Graph.append(Node, id="rabbit").

--- a/nodebox/graphics/shader.py
+++ b/nodebox/graphics/shader.py
@@ -5,13 +5,14 @@
 # Copyright (c) 2008-2012 City In A Bottle (cityinabottle.org)
 # http://cityinabottle.org/nodebox
 
-from pyglet.gl    import *
-from pyglet.image import Texture, SolidColorImagePattern
-from context      import Image, texture
-from geometry     import lerp, clamp
-from math         import radians
-from ctypes       import byref, cast, pointer, POINTER
-from ctypes       import c_char, c_char_p, c_uint, c_int
+# TODO: Look over this import syntax, it doesn't look at all standard...
+from pyglet.gl                     import *
+from pyglet.image                  import Texture, SolidColorImagePattern
+from math                          import radians
+from ctypes                        import byref, cast, pointer, POINTER
+from ctypes                        import c_char, c_char_p, c_uint, c_int
+from nodebox.graphics.context      import Image, texture
+from nodebox.graphics.geometry     import lerp, clamp
 
 def next(generator, default=None):
     try: 
@@ -268,7 +269,7 @@ def shader(vertex=DEFAULT_VERTEX_SHADER, fragment=DEFAULT_FRAGMENT_SHADER, silen
         return Shader(vertex, fragment)
     try:
         return Shader(vertex, fragment)
-    except Exception, e:
+    except Exception as e:
         SUPPORTED = False
         return ShaderFacade()
 
@@ -976,7 +977,7 @@ class OffscreenBuffer(object):
         self.id = c_uint(_uid())
         try: glGenFramebuffersEXT(1, byref(self.id))
         except:
-            raise OffscreenBufferError, "offscreen buffer not supported."
+            raise OffscreenBufferError("offscreen buffer not supported.")
         self.texture   = None
         self._viewport = (None, None, None, None) # The canvas bounds, set in OffscreenBuffer.push().
         self._active   = False
@@ -1018,7 +1019,7 @@ class OffscreenBuffer(object):
         # Check after glBindFramebufferEXT() and glFramebufferTexture2DEXT().
         if glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT) != GL_FRAMEBUFFER_COMPLETE_EXT:
             msg = self.texture.width == self.texture.height == 0 and "width=0, height=0." or ""
-            raise OffscreenBufferError, msg            
+            raise OffscreenBufferError(msg)
         # Separate the offscreen from the onscreen transform state.
         # Separate the offscreen from the onscreen canvas size.
         self._viewport = glCurrentViewport()
@@ -1081,7 +1082,7 @@ class OffscreenBuffer(object):
             between OffscreenBuffer.push() and OffscreenBuffer.pop() is retained.
         """
         if self._active:
-            raise OffscreenBufferError, "can't reset offscreen buffer when active"
+            raise OffscreenBufferError("can't reset offscreen buffer when active")
         if width is None:
             width = self.width
         if height is None:

--- a/nodebox/gui/controls.py
+++ b/nodebox/gui/controls.py
@@ -155,7 +155,7 @@ class Control(Layer):
         ctrl = nested(self, k)
         if ctrl is not None:
             return ctrl
-        raise AttributeError, "'%s' object has no attribute '%s'" % (self.__class__.__name__, k)
+        raise AttributeError("'" + str(self.__class__.__name__) + "' object has no attribute '" + str(k) + "'")
         
     def __repr__(self):
         return "%s(id=%s%s)" % (
@@ -668,8 +668,8 @@ class Editable(Control):
             self._editor.set_selection(i, i+1)
         if i == len(self.value) and self.value != "" and delimiter(self.value[i-1]):
             self._editor.set_selection(i-1, i)
-        a = _find(lambda (i,ch): delimiter(ch), enumerate(reversed(self.value[:i])))
-        b = _find(lambda (i,ch): delimiter(ch), enumerate(self.value[i:]))
+        a = _find(lambda i,ch: delimiter(ch), enumerate(reversed(self.value[:i])))
+        b = _find(lambda i,ch: delimiter(ch), enumerate(self.value[i:]))
         a = a and i-a[0] or 0
         b = b and i+b[0] or len(self.value)
         self._editor.set_selection(a, b)
@@ -1091,7 +1091,7 @@ class Layout(Layer):
         ctrl = nested(self, k)
         if ctrl is not None:
             return ctrl
-        raise AttributeError, "'%s' object has no attribute '%s'" % (self.__class__.__name__, k)
+        raise AttributeError("'" + str(self.__class__.__name__) + "' object has no attribute '" + str(k) + "'")
 
     def apply(self):
         """ Adjusts the position and size of the controls to match the layout.

--- a/nodebox/sound/osc.py
+++ b/nodebox/sound/osc.py
@@ -42,10 +42,10 @@ def hexDump(bytes):
     for i in range(len(bytes)):
         sys.stdout.write("%2x " % (ord(bytes[i])))
         if (i+1) % 8 == 0:
-            print repr(bytes[i-7:i+1])
+            print (repr(bytes[i-7:i+1]))
 
     if(len(bytes) % 8 != 0):
-        print string.rjust("", 11), repr(bytes[i-len(bytes)%8:i+1])
+        print (string.rjust("", 11), repr(bytes[i-len(bytes)%8:i+1]))
 
 
 class OSCMessage:
@@ -114,7 +114,7 @@ def readBlob(data):
 
 def readInt(data):
     if(len(data)<4):
-        print "Error: too few bytes for int", data, len(data)
+        print("Error: too few bytes for int", data, len(data))
         rest = data
         integer = 0
     else:
@@ -137,7 +137,7 @@ def readLong(data):
 
 def readFloat(data):
     if(len(data)<4):
-        print "Error: too few bytes for float", data, len(data)
+        print("Error: too few bytes for float", data, len(data))
         rest = data
         float = 0
     else:
@@ -191,7 +191,7 @@ def parseArgs(args):
     possible) as floats or integers."""
     parsed = []
     for arg in args:
-        print arg
+        print(arg)
         arg = arg.strip()
         interpretation = None
         try:
@@ -232,7 +232,7 @@ def decodeOSC(data):
                 value, rest = table[tag](rest)
                 decoded.append(value)
         else:
-            print "Oops, typetag lacks the magic ,"
+            print("Oops, typetag lacks the magic ,")
 
     return decoded
 
@@ -267,15 +267,15 @@ class CallbackManager:
                 for msg in message :
                     self.dispatch(msg, source)
 
-        except KeyError, e:
+        except KeyError as e:
             # address not found
-            print 'address %s not found ' % address
+            print('address ' + str(address) + ' not found')
             pprint.pprint(message)
-        except IndexError, e:
-            print 'got malformed OSC message'
+        except IndexError as e:
+            print('got malformed OSC message')
             pass
-        except None, e:
-            print "Exception in", address, "callback :", e
+        except None as e:
+            print("Exception in", address, "callback :", e)
 
         return
 
@@ -297,7 +297,7 @@ class CallbackManager:
 
 if __name__ == "__main__":
     hexDump("Welcome to the OSC testing program.")
-    print
+    print()
     message = OSCMessage()
     message.setAddress("/foo/play")
     message.append(44)
@@ -306,7 +306,7 @@ if __name__ == "__main__":
     message.append("the white cliffs of dover")
     hexDump(message.getBinary())
 
-    print "Making and unmaking a message.."
+    print("Making and unmaking a message..")
 
     strings = OSCMessage()
     strings.append("Mary had a little lamb")
@@ -321,26 +321,26 @@ if __name__ == "__main__":
 
     hexDump(raw)
 
-    print "Retrieving arguments..."
+    print("Retrieving arguments...")
     data = raw
     for i in range(6):
         text, data = readString(data)
-        print text
+        print(text)
 
     number, data = readFloat(data)
-    print number
+    print(number)
 
     number, data = readFloat(data)
-    print number
+    print(number)
 
     number, data = readInt(data)
-    print number
+    print(number)
 
     hexDump(raw)
-    print decodeOSC(raw)
-    print decodeOSC(message.getBinary())
+    print(decodeOSC(raw))
+    print(decodeOSC(message.getBinary()))
 
-    print "Testing Blob types."
+    print("Testing Blob types.")
 
     blob = OSCMessage()
     blob.append("","b")
@@ -353,7 +353,7 @@ if __name__ == "__main__":
 
     hexDump(blob.getBinary())
 
-    print decodeOSC(blob.getBinary())
+    print(decodeOSC(blob.getBinary()))
 
     def printingCallback(*stuff):
         sys.stdout.write("Got: ")
@@ -361,7 +361,7 @@ if __name__ == "__main__":
             sys.stdout.write(str(i) + " ")
         sys.stdout.write("\n")
 
-    print "Testing the callback manager."
+    print("Testing the callback manager.")
 
     c = CallbackManager()
     c.add(printingCallback, "/print")
@@ -388,7 +388,7 @@ if __name__ == "__main__":
 
     bundlebinary = bundle.message
 
-    print "sending a bundle to the callback manager"
+    print("sending a bundle to the callback manager")
     c.handle(bundlebinary)
 
 

--- a/nodebox/sound/process.py
+++ b/nodebox/sound/process.py
@@ -227,11 +227,11 @@ class PD(object):
         """
         if self.patch is None \
         or not os.path.exists(self.patch):
-            raise PDError, "no PD patch file at '%s'" % self.patch
+            raise PDError("no PD patch file at '" + str(self.patch) + "'")
         if not self._path:
-            raise PDError, "no PD application found"
+            raise PDError("no PD application found")
         if not os.path.exists(self._path):
-            raise PDError, "no PD application at '%s'" % self._path
+            raise PDError("no PD application at '" + str(self._path) + "'")
         if not self._process:
             self._process = Process(program=self._path, options=self._options)
     


### PR DESCRIPTION
This is a WIP copy of a version that is working in the sense that it's **able to install** and **run a basic examples** (without desired results?):

![Preview image](http://i.imgur.com/7L8omha.png)

Would love to see this merged into a new branch of the official repo.
I'm well aware that some of these conversions breaks backwards compability.
- the `canvas = Canvas()` definition in `./nodebox/graphics/__init__.py` confused me a bit, couldn't get it to go global in Python3 so i just created a wrapper function that returns it from the local scope whenever called.
- the `def draw()` function doesn't appear to actually draw anything, haven't really started to learn the library yet since i spent most of the day just converting old broken Py2.6 code up to speed. (not done yet perhaps).

Files modified in short:

```
nodebox-opengl-master\nodebox\ext\psyco\
    core.py
    kdictproxy.py
    profiler.py
    support.py
    __init__.py
nodebox-opengl-master\nodebox\graphics
    beizer.py
    context.py
    geometry.py
    physics.py
    shader.py
nodebox-opengl-master\nodebox\gui
    controls.py
nodebox-opengl-master\nodebox\sound
    osc.py
    process.py

```
